### PR TITLE
fix: wrap long dataset titles to prevent horizontal overflow

### DIFF
--- a/components/_shared/HeroSection.tsx
+++ b/components/_shared/HeroSection.tsx
@@ -20,7 +20,7 @@ export default function HeroSection({
             {eyebrow}
           </span>
         )}
-        <h1 className="mt-2 text-3xl md:text-[44px] font-extrabold leading-[1.12] tracking-tight text-accent capitalize">
+        <h1 className="mt-2 text-3xl md:text-[44px] font-extrabold leading-[1.12] tracking-tight text-accent capitalize break-words">
           {title}{" "}
           {titleAccent && <span className="text-eiti-navy2">{titleAccent}</span>}
         </h1>

--- a/components/dataset/individualPage/ResourcesList.tsx
+++ b/components/dataset/individualPage/ResourcesList.tsx
@@ -21,7 +21,7 @@ export default function ResourcesList({
           className="flex w-full flex-col gap-4 rounded-lg border border-eiti-border bg-white px-5 py-4 md:flex-row md:items-center md:justify-between"
         >
           <div className="min-w-0 grow">
-            <h4 className="text-[15px] font-bold leading-snug text-accent line-clamp-3">
+            <h4 className="text-[15px] font-bold leading-snug text-accent line-clamp-3 break-words">
               {resource.name || "No title"}
             </h4>
             {resource.description ? (

--- a/components/dataset/search/DatasetItem.tsx
+++ b/components/dataset/search/DatasetItem.tsx
@@ -15,7 +15,7 @@ export default function DatasetItem({
       href={`/@${dataset.organization.name}/${dataset.name}`}
       className="group block rounded-lg border border-eiti-border bg-white p-5 transition-all hover:border-eiti-borderinput hover:shadow-sm"
     >
-      <div className="text-[17px] font-extrabold leading-snug text-accent">
+      <div className="text-[17px] font-extrabold leading-snug text-accent break-words">
         <span className="border-b-2 border-transparent group-hover:border-eiti-amber">
           {dataset.title}
         </span>

--- a/components/home/mainSection/MainSection.tsx
+++ b/components/home/mainSection/MainSection.tsx
@@ -124,7 +124,7 @@ export default function MainSection({
             allHref="/search"
             allLabel="All datasets"
           />
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
             {datasets
               .filter((dataset) => dataset.organization?.name)
               .slice(0, 3)
@@ -132,15 +132,15 @@ export default function MainSection({
               <Link
                 key={dataset.id}
                 href={`/@${dataset.organization?.name}/${dataset.name}`}
-                className="flex min-h-[128px] flex-col justify-between rounded-lg border border-eiti-border border-l-2 border-l-eiti-amber bg-white px-5 py-4 transition-all hover:border-eiti-borderinput hover:shadow-sm"
+                className="flex min-h-[128px] min-w-0 flex-col justify-between rounded-lg border border-eiti-border border-l-2 border-l-eiti-amber bg-white px-5 py-4 transition-all hover:border-eiti-borderinput hover:shadow-sm"
               >
-                <div>
+                <div className="min-w-0">
                   {dataset.metadata_modified && (
                     <div className="mb-1 text-[10px] font-bold uppercase tracking-label text-eiti-amberink">
                       Updated {getTimeAgo(dataset.metadata_modified)}
                     </div>
                   )}
-                  <div className="text-base font-extrabold leading-snug text-accent">
+                  <div className="text-base font-extrabold leading-snug text-accent break-words">
                     {dataset.title || dataset.name}
                   </div>
                 </div>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -75,7 +75,7 @@ function SearchPageContent() {
           <div className="lg:col-span-3 lg:sticky top-3 h-fit">
             <DatasetSearchFilters />
           </div>
-          <div className="lg:col-span-6">
+          <div className="lg:col-span-6 min-w-0">
             <ListOfDatasets />
           </div>
         </article>


### PR DESCRIPTION
A dataset whose title is a long unbroken token — for example the filename-style
slug `Itie_mocambique_8o_relatorio_i2a_consultoria_versao_final_28022020_eng` —
has no break opportunity, so it stretches its container wider than the viewport.
On the dataset page the title runs off the right edge. On the mobile home page
the same title stretches a card in the latest-datasets grid, which pushes the
whole document wider than the screen, so the hero no longer spans the viewport
and leaves dead space to the right.

This wraps those titles and lets their grid and flex tracks shrink below their
content width, so a long token can no longer force a track wider than the
viewport.

## Changes

**fix: wrap long dataset titles**
- Add `break-words` to the page title (`HeroSection`), the home latest-datasets
  card title, the search-result title (`DatasetItem`), and the resource name
  (`ResourcesList`).
- → Long unbroken titles wrap instead of overflowing their container.

**fix: constrain grid and flex tracks**
- Make the home latest-datasets grid single-column on mobile (`grid-cols-1`)
  with `min-w-0` cards, and add `min-w-0` to the search results column.
- → A long token can no longer stretch a track past the viewport, so the
  mobile hero spans the full width again.

## Test plan
- [x] Home, dataset, and search pages show zero horizontal overflow at a mobile
  viewport (DevTools: `documentScrollWidth === clientWidth`).
- [x] The Mozambique dataset title wraps to three lines within the viewport on
  its dataset page.
- [x] The mobile hero background spans the full viewport width.
- [x] Accessibility CI passes on the fork.
- [x] `eslint` clean on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping for long titles across hero sections, resource titles, dataset items, and dataset cards by enabling word-breaking.
  * Refined responsive dataset grid behavior on small screens (single-column layout, consistent spacing) to reduce overflow.
  * Stabilized the search results layout on constrained widths by ensuring containers can shrink properly (`min-width: 0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->